### PR TITLE
fix(package): add exports types

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "description": "",
   "source": "src/BarcodeDetector.ts",
   "main": "dist/barcode-detector.js",
-  "exports": "./dist/barcode-detector.modern.js",
+  "exports": { ".": { "import": "./dist/barcode-detector.modern.js", "types": "./dist/BarcodeDetector.d.ts" }},
   "module": "dist/barcode-detector.module.js",
   "unpkg": "dist/barcode-detector.umd.js",
   "amdName": "BarcodeDetectorPolyfill",


### PR DESCRIPTION
This way depending projects using typescript don't show a missing types error.