### PR TITLE
Fix attempt to decode inverted QR code

### DIFF
--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -10,7 +10,7 @@ function detectWithJsQR(imageData : ImageData) : Array<DetectedBarcode> {
       imageData.data, 
       imageData.width, 
       imageData.height, 
-      { inversionAttempts: "dontInvert" }
+      { inversionAttempts: "attemptBoth" }
     );
 
     if (qrcode === null || qrcode.data === "") {


### PR DESCRIPTION
change detection strategy to also consider inverted QR codes.

According to https://github.com/cozmo/jsQR this is 50% slower, but seems still be better than ignoring inverted codes. It might make sense to expose this setting in the future.

Related Issue https://github.com/gruhn/vue-qrcode-reader/issues/238