### PR TITLE
Publish types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 inline-worker.js
 dist/
+*.tgz

--- a/package.json
+++ b/package.json
@@ -13,11 +13,13 @@
   "main": "dist/barcode-detector.js",
   "exports": {
     ".": {
-      "import": "./dist/barcode-detector.js",
-      "types": "./dist/BarcodeDetector.d.ts"
+      "types": "./dist/BarcodeDetector.d.ts",
+      "import": "./dist/barcode-detector.mjs",
+      "require": "./dist/barcode-detector.js"
     }
   },
-  "module": "dist/barcode-detector.module.js",
+  "types": "dist/BarcodeDetector.d.ts",
+  "module": "dist/barcode-detector.mjs",
   "unpkg": "dist/barcode-detector.umd.js",
   "amdName": "BarcodeDetectorPolyfill",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,5 +33,11 @@
   "devDependencies": {
     "microbundle": "^0.13.3",
     "semantic-release": "^17.4.3"
-  }
+  },
+  "files": [
+    "dist",
+    "example_codes",
+    "src",
+    "!src/worker/node_modules"
+  ]
 }

--- a/src/BarcodeDetector.ts
+++ b/src/BarcodeDetector.ts
@@ -1,3 +1,3 @@
-import BarcodeDetector from "./BarcodeDetectorJsqr"
+import BarcodeDetector from "./BarcodeDetectorJsqr.js";
 
 export default BarcodeDetector

--- a/src/BarcodeDetectorJsqr.ts
+++ b/src/BarcodeDetectorJsqr.ts
@@ -1,9 +1,9 @@
 // spec: https://wicg.github.io/shape-detection-api/#barcode-detection-api  
 
-import { BarcodeDetectorOptions, BarcodeFormat, DetectedBarcode } from "./basic-types"
-import { imageDataFrom } from "./image-data"
-import  SleepyWorker  from "./SleepyWorker"
-import inlineWorkerCode from "./worker/inline-worker"
+import { BarcodeDetectorOptions, BarcodeFormat, DetectedBarcode } from "./basic-types.js"
+import { imageDataFrom } from "./image-data.js"
+import  SleepyWorker  from "./SleepyWorker.js"
+import inlineWorkerCode from "./worker/inline-worker.js"
 
 const allSupportedFormats : BarcodeFormat[] = [ "qr_code" ]
 

--- a/src/BarcodeDetectorZXing.ts
+++ b/src/BarcodeDetectorZXing.ts
@@ -1,7 +1,7 @@
 // spec: https://wicg.github.io/shape-detection-api/#barcode-detection-api  
 
-import { BarcodeDetectorOptions, BarcodeFormat, DetectedBarcode } from "./basic-types"
-import { imageDataFrom } from "./image-data"
+import { BarcodeDetectorOptions, BarcodeFormat, DetectedBarcode } from "./basic-types.js"
+import { imageDataFrom } from "./image-data.js"
 import * as ZXing from "@zxing/library"
 
 const mapFormat = new Map<BarcodeFormat, ZXing.BarcodeFormat>([

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ESNext"
+  },
+  "include": ["src"],
+  "exclude": ["src/worker"]
+}


### PR DESCRIPTION
Closes #10 

Sooo, it isn't perfect* - I've had problems configuring microbundle to output separate typings for CJS and ESM - but it's much better than it used to be. Here are outputs of arethetypeswrong (which actually tells a lot more, especially about module resolution):

Before:
<img width="891" alt="image" src="https://github.com/gruhn/barcode-detector/assets/5426427/54408a5f-93b8-4c46-a0cb-7c83e9cbbb1b">

After:
<img width="891" alt="image" src="https://github.com/gruhn/barcode-detector/assets/5426427/3f4bf20f-10ef-4a6f-ab6a-675cbdd846a8">

\* - "isn't perfect" means that it has incorrect types for (rather rare) setup: Node.js >=16 + TypeScript + moduleResolution: "node16"/"nodenext". The question is, why would you need barcode-detector in Node.js.
